### PR TITLE
Fix the branch name in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test last-assigned
+name: Test
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - primary
 
 jobs:
   unitTest:


### PR DESCRIPTION
The default branch is named `primary` now, so we need to fix this reference.